### PR TITLE
Allow r/w from the same group over unix socket

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,7 +353,7 @@ dependencies = [
 
 [[package]]
 name = "dkim-milter"
-version = "0.2.0-alpha.1"
+version = "0.2.0"
 dependencies = [
  "byte-strings",
  "domain",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dkim-milter"
-version = "0.2.0-alpha.1"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.74.0"
 description = "Milter for DKIM signing and verification"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 > [!NOTE]
 > This is a fork of https://codeberg.org/glts/dkim-milter
+> 
+> Chatmail-specific patches:
+> - unix sockets use 760 mode
 
 # DKIM Milter
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,8 @@ use std::{
     path::Path,
     process,
 };
+use std::fs::Permissions;
+use std::os::unix::fs::PermissionsExt;
 use tokio::{
     fs,
     net::{TcpListener, UnixListener},
@@ -94,6 +96,11 @@ async fn main() {
                     process::exit(1);
                 }
             };
+
+            // Allow r/w from the same group
+            fs::set_permissions(path, Permissions::from_mode(0o760))
+                .await
+                .expect("Failed to set UNIX domain socket permissions");
 
             // Remember the socket file path, and delete it on shutdown.
             addr = listener.local_addr().unwrap();


### PR DESCRIPTION
This is required for communication with postfix (using different user) over unix domain socket.